### PR TITLE
Resolving build errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,9 +8,6 @@ allprojects {
     repositories {
         flatDir dirs: "${rootDir}/libs"
         mavenCentral()
-        maven {
-            url "https://dl.bintray.com/ihmcrobotics/maven-release/"
-        }
     }
 
     apply plugin: 'checkstyle'
@@ -27,7 +24,7 @@ allprojects {
         targetCompatibility = 1.8
 
         ext {
-            ihmc_version = "0.14.0"
+            ihmc_version = "0.16.1"
         }
 
         dependencies {

--- a/camel/README.md
+++ b/camel/README.md
@@ -16,7 +16,7 @@ Add the IHMC repository:
 ```
 Add the camel component dependency, where `dds_camel_version` is the latest artifact version:
 ```groovy
-implementation("com.chesapeaketechnology:dds:${dds_camel_version}")
+implementation("com.chesapeaketechnology:ihmc-dds:${dds_camel_version}")
 ```
 
 ### Camel Component

--- a/camel/build.gradle
+++ b/camel/build.gradle
@@ -29,7 +29,7 @@ publishing {
             from components.java
 
             groupId = 'com.chesapeaketechnology'
-            artifactId = 'dds'
+            artifactId = 'ihmc-dds'
             version = rootProject.version
 
             artifact tasks.sourceJar

--- a/idl-tools/README.md
+++ b/idl-tools/README.md
@@ -88,11 +88,9 @@ A collection of tools to automate the process of generating Java classes from ID
 * For the current project
     1. Run `gradle compileSources`
 * For your own project
-    1. Add the IHMC repository to your project 
-        * `maven { url "https://dl.bintray.com/ihmcrobotics/maven-release/" }`
-    2. Add this project as a dependency
-        * `implementation("com.chesapeaketechnology:dds:${dds_camel_version}")`
-    3. Create a gradle `JavaExec` task that calls `com.chesapeaketechnology.idl.Tool` with the specified arguments for each command you want to run
+    1. Add this project as a dependency
+        * `implementation("com.chesapeaketechnology:ihmc-dds:${dds_camel_version}")`
+    2. Create a gradle `JavaExec` task that calls `com.chesapeaketechnology.idl.Tool` with the specified arguments for each command you want to run
 
 **Example configuration:**
 ```groovy

--- a/idl-tools/build.gradle
+++ b/idl-tools/build.gradle
@@ -88,6 +88,6 @@ repositories {
 dependencies {
     compile group: "us.ihmc", name: "ihmc-pub-sub-generator", version: "$ihmc_version"
     compile group: 'info.picocli', name: 'picocli', version: '4.2.0'
-    compile group: 'com.github.javaparser', name: 'javaparser-core', version: '3.15.21'
+    compile group: 'com.github.javaparser', name: 'javaparser-core', version: '3.22.1'
     runtimeOnly fileTree(dir: 'compat/cafe', include: ['*.class'])
 }


### PR DESCRIPTION
Upstream IHMC artifacts have been shuffled around, swapping out for he new artifacts on central resolves the build errors.