### PR TITLE
Compatibility with Cafe-Vortex

### DIFF
--- a/idl-tools/src/main/java/com/chesapeaketechnology/idl/GenerateSrc.java
+++ b/idl-tools/src/main/java/com/chesapeaketechnology/idl/GenerateSrc.java
@@ -4,8 +4,8 @@ import com.chesapeaketechnology.idl.util.FileUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.Parameters;
 import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
 import us.ihmc.commons.nio.FileTools;
 import us.ihmc.idl.generator.IDLGenerator;
 

--- a/idl-tools/src/main/java/com/chesapeaketechnology/idl/Tool.java
+++ b/idl-tools/src/main/java/com/chesapeaketechnology/idl/Tool.java
@@ -12,10 +12,10 @@ import java.util.concurrent.Callable;
  */
 @Command(subcommands = {
         GenerateSrc.class,
-        CompileSrc.class,
-        Pack.class,
         Process.class,
-        Compat.class
+        Compat.class,
+        CompileSrc.class,
+        Pack.class
 })
 public class Tool implements Callable<Void>
 {

--- a/idl-tools/src/main/java/com/chesapeaketechnology/idl/patch/CompatibilityProcessor.java
+++ b/idl-tools/src/main/java/com/chesapeaketechnology/idl/patch/CompatibilityProcessor.java
@@ -65,14 +65,14 @@ public class CompatibilityProcessor extends AbstractProcessor
                 setCode(cu.toString().replaceAll("(?<=\\w)_(?=\\b)", ""));
                 break;
             default:
-               break;
+                break;
         }
         return getCode();
     }
 
     private void visitCafeInherits(CompilationUnit cu)
     {
-        cu.getImports().add(new ImportDeclaration("org.omg.CORBA.portable.IDLEntity", false ,false));
+        cu.getImports().add(new ImportDeclaration("org.omg.CORBA.portable.IDLEntity", false, false));
         cu.getClassByName(getPrimaryType(cu)).get().addImplementedType("IDLEntity");
     }
 
@@ -121,7 +121,8 @@ public class CompatibilityProcessor extends AbstractProcessor
             // Update all statements to include "this" qualifier
             for (Statement n : dec.getBody().get().getStatements())
             {
-                if (n instanceof ExpressionStmt) {
+                if (n instanceof ExpressionStmt)
+                {
                     ExpressionStmt curStmt = (ExpressionStmt) n;
                     String curStmtText = curStmt.getExpression().toString();
                     if (!curStmtText.contains(IHMC_COPY))

--- a/idl-tools/src/main/java/com/chesapeaketechnology/idl/patch/CompatibilityProcessor.java
+++ b/idl-tools/src/main/java/com/chesapeaketechnology/idl/patch/CompatibilityProcessor.java
@@ -2,6 +2,7 @@ package com.chesapeaketechnology.idl.patch;
 
 import com.chesapeaketechnology.idl.CompatibilityType;
 import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.ImportDeclaration;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.FieldDeclaration;
@@ -53,6 +54,8 @@ public class CompatibilityProcessor extends AbstractProcessor
         {
             case CAFE:
                 CompilationUnit cu = createCompilationUnit();
+                // Implement IDLEntity
+                visitCafeInherits(cu);
                 // Add KeyList annotation
                 visitCafeAnnotation(cu);
                 // Add "this" qualifier to expressions
@@ -65,6 +68,12 @@ public class CompatibilityProcessor extends AbstractProcessor
                break;
         }
         return getCode();
+    }
+
+    private void visitCafeInherits(CompilationUnit cu)
+    {
+        cu.getImports().add(new ImportDeclaration("org.omg.CORBA.portable.IDLEntity", false ,false));
+        cu.getClassByName(getPrimaryType(cu)).get().addImplementedType("IDLEntity");
     }
 
     private void visitCafeAnnotation(CompilationUnit cu)


### PR DESCRIPTION
WIP as this requires some significant testing. 

**Goals**

- Allow a generated JAR of IDL defined types to be used both for IHMC and Cafe-Vortex using `idl-tools`
- Validate that IHMC and Cafe-Vortex can communicate in the same domain when sharing the same JAR of IDL defined types